### PR TITLE
feat: multiple instances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,11 @@
         },
         "sort-packages": true
     },
+    "extra" : {
+	"branch-alias": {
+		"dev-main": "1.x-dev"
+	}
+    },
     "scripts": {
         "post-install-cmd": "phive --no-progress install --force-accept-unsigned --trust-gpg-keys C00543248C87FB13,4AA394086372C20A,CF1A108D0E7AE720,51C67305FFC2E5C0,E82B2FB314E9906E",
         "analyse": [

--- a/composer.json
+++ b/composer.json
@@ -64,10 +64,10 @@
         },
         "sort-packages": true
     },
-    "extra" : {
-	"branch-alias": {
-		"dev-main": "1.x-dev"
-	}
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.x-dev"
+        }
     },
     "scripts": {
         "post-install-cmd": "phive --no-progress install --force-accept-unsigned --trust-gpg-keys C00543248C87FB13,4AA394086372C20A,CF1A108D0E7AE720,51C67305FFC2E5C0,E82B2FB314E9906E",
@@ -78,7 +78,7 @@
             "@analyse:compatibilitycheck"
         ],
         "analyse:compatibilitycheck": "./vendor/bin/phpcs --standard=./phpcs.compatibilitycheck.xml",
-	"analyse:phpcsfixer": "./tools/php-cs-fixer check --diff --show-progress=dots",
+        "analyse:phpcsfixer": "./tools/php-cs-fixer check --diff --show-progress=dots",
         "analyse:phplint": "./tools/phplint",
         "analyse:phpstan": "./tools/phpstan analyse",
         "cs-fix": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a273a82602dfa2f443cf3cc461d74152",
+    "content-hash": "a02c99176ab7ba2f637081520dff0eae",
     "packages": [
         {
             "name": "atoolo/resource-bundle",
@@ -4635,16 +4635,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.24",
+            "version": "10.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015"
+                "reference": "831bf82312be6037e811833ddbea0b8de60ea314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f124e3e3e561006047b532fd0431bf5bb6b9015",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/831bf82312be6037e811833ddbea0b8de60ea314",
+                "reference": "831bf82312be6037e811833ddbea0b8de60ea314",
                 "shasum": ""
             },
             "require": {
@@ -4716,7 +4716,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.25"
             },
             "funding": [
                 {
@@ -4732,7 +4732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T13:09:54+00:00"
+            "time": "2024-07-03T05:49:17+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4740,12 +4740,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "27714b56f04815b654c3805502ab77207505ac19"
+                "reference": "fed98f59fae0ca97a0753263270f4a8680d09f03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/27714b56f04815b654c3805502ab77207505ac19",
-                "reference": "27714b56f04815b654c3805502ab77207505ac19",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/fed98f59fae0ca97a0753263270f4a8680d09f03",
+                "reference": "fed98f59fae0ca97a0753263270f4a8680d09f03",
                 "shasum": ""
             },
             "conflict": {
@@ -4753,6 +4753,8 @@
                 "admidio/admidio": "<4.2.13",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<2.2",
+                "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.04.6",
+                "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
                 "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
@@ -5537,7 +5539,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-26T15:05:17+00:00"
+            "time": "2024-07-02T22:05:16+00:00"
         },
         {
             "name": "sanmai/later",

--- a/composer.lock
+++ b/composer.lock
@@ -6930,5 +6930,5 @@
         "ext-zip": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,9 @@ services:
       - '@atoolo_search.indexer.status_store'
       - 'rce-event'
 
+  atoolo_events_calendar.indexer.rceEventFilter:
+    class: Atoolo\EventsCalendar\Service\Indexer\RceEventIndexerDateFilter
+
   Atoolo\EventsCalendar\Service\Indexer\RceEventIndexer:
     arguments:
       - !tagged_iterator { tag: 'atoolo_events_calendar.indexer.rceEventDocumentEnricher.schema2x' }
@@ -45,6 +48,7 @@ services:
       - '@atoolo_search.indexer.solr_index_service'
       - '@atoolo_search.index_name'
       - '@atoolo_search.indexer.configuration_loader'
+      - '@atoolo_events_calendar.indexer.rceEventFilter'
       - 'rce-event'
     tags:
       - { name: 'atoolo_search.indexer', priority: 10 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,7 +36,7 @@ services:
       - '@atoolo_search.indexer.status_store'
       - 'rce-event'
 
-  atoolo_events_calendar.indexer.rceEventFilter:
+  atoolo_events_calendar.indexer.rce_event_filter:
     class: Atoolo\EventsCalendar\Service\Indexer\RceEventIndexerDateFilter
 
   Atoolo\EventsCalendar\Service\Indexer\RceEventIndexer:
@@ -48,7 +48,7 @@ services:
       - '@atoolo_search.indexer.solr_index_service'
       - '@atoolo_search.index_name'
       - '@atoolo_search.indexer.configuration_loader'
-      - '@atoolo_events_calendar.indexer.rceEventFilter'
+      - '@atoolo_events_calendar.indexer.rce_event_filter'
       - 'rce-event'
     tags:
       - { name: 'atoolo_search.indexer', priority: 10 }

--- a/src/Dto/Indexer/RceEventIndexerInstance.php
+++ b/src/Dto/Indexer/RceEventIndexerInstance.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Dto\Indexer;
+
+/**
+ * @codeCoverageIgnore
+ */
+class RceEventIndexerInstance
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $detailPageUrl,
+        public readonly int $group,
+        public readonly array $groupPath,
+    ) {}
+}

--- a/src/Dto/Indexer/RceEventIndexerParameter.php
+++ b/src/Dto/Indexer/RceEventIndexerParameter.php
@@ -11,13 +11,12 @@ class RceEventIndexerParameter
 {
     /**
      * @param int[] $groupPath
-     * @param string[] $categoryRootResourceLocations
+     * @param array<RceEventIndexerInstance> $instanceList
+     * @param array<string> $categoryRootResourceLocations
      */
     public function __construct(
         public readonly string $source,
-        public readonly string $detailPageUrl,
-        public readonly int $group,
-        public readonly array $groupPath,
+        public readonly array $instanceList,
         public readonly array $categoryRootResourceLocations,
         public readonly int $cleanupThreshold,
         public readonly string $exportUrl,

--- a/src/Service/Indexer/RceEventDocumentEnricher.php
+++ b/src/Service/Indexer/RceEventDocumentEnricher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\EventsCalendar\Service\Indexer;
 
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerInstance;
 use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerParameter;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
@@ -21,6 +22,7 @@ interface RceEventDocumentEnricher
      */
     public function enrichDocument(
         RceEventIndexerParameter $parameter,
+        RceEventIndexerInstance $instance,
         RceEventListItem $event,
         RceEventDate $eventDate,
         IndexDocument $doc,

--- a/src/Service/Indexer/RceEventIndexer.php
+++ b/src/Service/Indexer/RceEventIndexer.php
@@ -20,7 +20,6 @@ use Atoolo\Search\Service\Indexer\IndexSchema2xDocument;
 use Atoolo\Search\Service\Indexer\SolrIndexService;
 use Atoolo\Search\Service\Indexer\SolrIndexUpdater;
 use Atoolo\Search\Service\IndexName;
-use DateTime;
 use Exception;
 use Throwable;
 
@@ -153,8 +152,6 @@ class RceEventIndexer extends AbstractIndexer
     ): int {
 
         $count = 0;
-        $startOfToday = new DateTime();
-        $startOfToday->setTime(0, 0);
         foreach ($event->dates as $eventDate) {
             if ($this->filter->accept($event, $eventDate) === false) {
                 $this->progressHandler->skip(1);

--- a/src/Service/Indexer/RceEventIndexer.php
+++ b/src/Service/Indexer/RceEventIndexer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\EventsCalendar\Service\Indexer;
 
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerInstance;
 use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerParameter;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
@@ -19,6 +20,7 @@ use Atoolo\Search\Service\Indexer\IndexSchema2xDocument;
 use Atoolo\Search\Service\Indexer\SolrIndexService;
 use Atoolo\Search\Service\Indexer\SolrIndexUpdater;
 use Atoolo\Search\Service\IndexName;
+use DateTime;
 use Exception;
 use Throwable;
 
@@ -36,6 +38,7 @@ class RceEventIndexer extends AbstractIndexer
         private readonly SolrIndexService $indexService,
         IndexName $index,
         IndexerConfigurationLoader $configLoader,
+        private readonly RceEventIndexerFilter $filter,
         string $source,
     ) {
         parent::__construct(
@@ -58,25 +61,30 @@ class RceEventIndexer extends AbstractIndexer
 
         $this->rceEventListReader->read($parameter->exportUrl);
 
-        $this->progressHandler->start($this->countEventDates());
+        $this->progressHandler->start(
+            $this->countEventDates() * count($parameter->instanceList),
+        );
 
         $updater = $this->indexService->updater(ResourceLanguage::default());
 
         $processId = uniqid('', true);
         $successCount = 0;
 
-        foreach ($this->rceEventListReader->getItems() as $rceEvent) {
-            if (
-                $this->isAbortionRequested()
-            ) {
-                return $this->progressHandler->getStatus();
+        foreach ($parameter->instanceList as $instance) {
+            foreach ($this->rceEventListReader->getItems() as $rceEvent) {
+                if (
+                    $this->isAbortionRequested()
+                ) {
+                    return $this->progressHandler->getStatus();
+                }
+                $successCount += $this->indexEvent(
+                    $updater,
+                    $parameter,
+                    $instance,
+                    $rceEvent,
+                    $processId,
+                );
             }
-            $successCount += $this->indexEvent(
-                $updater,
-                $parameter,
-                $rceEvent,
-                $processId,
-            );
         }
 
         $result = $updater->update();
@@ -117,11 +125,19 @@ class RceEventIndexer extends AbstractIndexer
         $categoryRootResourceLocations =
             $data->getArray('categoryRootResourceLocations');
 
+        $instanceList = [];
+        foreach ($data->getArray('instanceList') as $instance) {
+            $instanceList[] = new RceEventIndexerInstance(
+                $instance['id'],
+                $instance['detailPageUrl'],
+                $instance['group'],
+                $instance['groupPath'],
+            );
+        }
+
         return new RceEventIndexerParameter(
             source: $this->source,
-            detailPageUrl: $data->getString('detailPageUrl'),
-            group: $data->getInt('group'),
-            groupPath: $groupPath,
+            instanceList: $instanceList,
             categoryRootResourceLocations: $categoryRootResourceLocations,
             cleanupThreshold: $data->getInt('cleanupThreshold'),
             exportUrl: $data->getString('exportUrl'),
@@ -131,15 +147,23 @@ class RceEventIndexer extends AbstractIndexer
     private function indexEvent(
         SolrIndexUpdater $updater,
         RceEventIndexerParameter $parameter,
+        RceEventIndexerInstance $instance,
         RceEventListItem $event,
         string $processId,
     ): int {
 
         $count = 0;
+        $startOfToday = new DateTime();
+        $startOfToday->setTime(0, 0);
         foreach ($event->dates as $eventDate) {
+            if ($this->filter->accept($event, $eventDate) === false) {
+                $this->progressHandler->skip(1);
+                continue;
+            }
             $count += $this->indexEventDate(
                 $updater,
                 $parameter,
+                $instance,
                 $event,
                 $eventDate,
                 $processId,
@@ -151,6 +175,7 @@ class RceEventIndexer extends AbstractIndexer
     private function indexEventDate(
         SolrIndexUpdater $updater,
         RceEventIndexerParameter $parameter,
+        RceEventIndexerInstance $instance,
         RceEventListItem $event,
         RceEventDate $eventDate,
         string $processId,
@@ -166,6 +191,7 @@ class RceEventIndexer extends AbstractIndexer
                 /** @var IndexSchema2xDocument $doc */
                 $doc = $enricher->enrichDocument(
                     $parameter,
+                    $instance,
                     $event,
                     $eventDate,
                     $doc,

--- a/src/Service/Indexer/RceEventIndexerDateFilter.php
+++ b/src/Service/Indexer/RceEventIndexerDateFilter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Service\Indexer;
+
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
+use DateTime;
+
+class RceEventIndexerDateFilter implements RceEventIndexerFilter
+{
+    private DateTime $date;
+    public function __construct(
+        ?DateTime $date = null,
+    ) {
+        if ($date === null) {
+            $date = new DateTime();
+            $date->setTime(0, 0);
+        }
+        $this->date = $date;
+    }
+    public function accept(
+        RceEventListItem $event,
+        RceEventDate $eventDate,
+    ): bool {
+        return $eventDate->startDate >= $this->date;
+    }
+}

--- a/src/Service/Indexer/RceEventIndexerFilter.php
+++ b/src/Service/Indexer/RceEventIndexerFilter.php
@@ -11,6 +11,6 @@ interface RceEventIndexerFilter
 {
     public function accept(
         RceEventListItem $event,
-        RceEventDate $eventDate
+        RceEventDate $eventDate,
     ): bool;
 }

--- a/src/Service/Indexer/RceEventIndexerFilter.php
+++ b/src/Service/Indexer/RceEventIndexerFilter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Service\Indexer;
+
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
+
+interface RceEventIndexerFilter
+{
+    public function accept(
+        RceEventListItem $event,
+        RceEventDate $eventDate
+    ): bool;
+}

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\EventsCalendar\Service\Indexer\SiteKit;
 
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerInstance;
 use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerParameter;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
@@ -44,15 +45,18 @@ class DefaultSchema2xRceEventDocumentEnricher implements
 
     public function enrichDocument(
         RceEventIndexerParameter $parameter,
+        RceEventIndexerInstance $instance,
         RceEventListItem $event,
         RceEventDate $eventDate,
         IndexDocument $doc,
         string $processId,
     ): IndexDocument {
 
-        $url = $parameter->detailPageUrl . '?id=' . $eventDate->hashId;
+        $url = $instance->detailPageUrl . '?id=' . $eventDate->hashId;
 
         $doc->id = $parameter->source
+            . '-'
+            . $instance->id
             . '-'
             . $event->id
             . '-'
@@ -67,9 +71,9 @@ class DefaultSchema2xRceEventDocumentEnricher implements
 
         $doc->crawl_process_id = $processId;
 
-        $doc->sp_group = $parameter->group;
-        if (!empty($parameter->groupPath)) {
-            $doc->sp_group_path = $parameter->groupPath;
+        $doc->sp_group = $instance->group;
+        if (!empty($instance->groupPath)) {
+            $doc->sp_group_path = $instance->groupPath;
         }
 
         if ($event->onsite) {

--- a/test/Service/Indexer/RceEventIndexerDateFilterTest.php
+++ b/test/Service/Indexer/RceEventIndexerDateFilterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Test\Service\Indexer;
+
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
+use Atoolo\EventsCalendar\Service\Indexer\RceEventIndexerDateFilter;
+use DateTime;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RceEventIndexerDateFilter::class)]
+class RceEventIndexerDateFilterTest extends TestCase
+{
+    public function testWithDefaultDate(): void
+    {
+        $filter = new RceEventIndexerDateFilter();
+
+        $now = new DateTime();
+        $event = $this->createStub(RceEventListItem::class);
+        $eventDate  = new RceEventDate(
+            hashId: '',
+            startDate: $now,
+            endDate: $now,
+            blacklisted: false,
+            soldOut: false,
+            cancelled: false,
+        );
+
+        $this->assertTrue(
+            $filter->accept($event, $eventDate),
+            'Event should be accepted',
+        );
+    }
+
+    public function testWithGivenDate(): void
+    {
+        $filter = new RceEventIndexerDateFilter(
+            new DateTime('2023-07-04'),
+        );
+
+        $date = new DateTime('2023-07-05');
+        $event = $this->createStub(RceEventListItem::class);
+        $eventDate  = new RceEventDate(
+            hashId: '',
+            startDate: $date,
+            endDate: $date,
+            blacklisted: false,
+            soldOut: false,
+            cancelled: false,
+        );
+
+        $this->assertTrue(
+            $filter->accept($event, $eventDate),
+            'Event should be accepted',
+        );
+    }
+}

--- a/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricherTest.php
+++ b/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\EventsCalendar\Test\Service\Indexer\SiteKit;
 
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerInstance;
 use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerParameter;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventAddress;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventAddresses;
@@ -44,11 +45,15 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
     {
         $loader = $this->createHierarchyLoader();
 
-        $this->parameter = new RceEventIndexerParameter(
-            'test',
+        $instance = new RceEventIndexerInstance(
+            1,
             'https://www.example.com/details.php',
             3,
             [1, 2, 3],
+        );
+        $this->parameter = new RceEventIndexerParameter(
+            'test',
+            [$instance],
             $this->rootResources,
             1,
             '',
@@ -75,6 +80,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -88,7 +94,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $expected->sp_sortvalue = 'myname';
         $expected->description = 'description';
         $expected->crawl_process_id = 'process-id';
-        $expected->id = 'test-123-hash';
+        $expected->id = 'test-1-123-hash';
         $expected->url = 'https://www.example.com/details.php?id=hash';
         $expected->contenttype = 'text/html; charset=UTF-8';
         $expected->sp_contenttype = [
@@ -139,6 +145,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -164,6 +171,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -195,6 +203,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -228,6 +237,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -261,6 +271,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -294,6 +305,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -327,6 +339,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -359,6 +372,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,
@@ -392,6 +406,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $enrichedDoc = $this->enricher->enrichDocument(
             $this->parameter,
+            $this->parameter->instanceList[0],
             $event,
             $event->dates[0],
             $doc,


### PR DESCRIPTION
In order to be able to use the RCE events in different event calendar instances, the indexer must also support this.

In addition, it has been corrected that expired events are not included in the index.