### PR TITLE
fix: event categorization

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,10 @@ services:
     autowire: true
     autoconfigure: true
 
+  Atoolo\EventsCalendar\Service\Indexer\SiteKit\DefaultSchema2xEventDocumentEnricher:
+    tags:
+      - { name: 'atoolo_search.indexer.document_enricher.schema2x', priority: 50 }
+
   Atoolo\EventsCalendar\Service\Indexer\SiteKit\DefaultSchema2xRceEventDocumentEnricher:
     arguments:
       - '@atoolo_resource.category_hierarchy_loader'

--- a/src/Dto/Indexer/RceEventIndexerParameter.php
+++ b/src/Dto/Indexer/RceEventIndexerParameter.php
@@ -17,6 +17,7 @@ class RceEventIndexerParameter
         public readonly string $source,
         public readonly array $instanceList,
         public readonly array $categoryRootResourceLocations,
+        public readonly int $highlightCategory,
         public readonly int $cleanupThreshold,
         public readonly string $exportUrl,
     ) {}

--- a/src/Service/Indexer/RceEventIndexer.php
+++ b/src/Service/Indexer/RceEventIndexer.php
@@ -145,6 +145,7 @@ class RceEventIndexer extends AbstractIndexer
             source: $this->source,
             instanceList: $instanceList,
             categoryRootResourceLocations: $categoryRootResourceLocations,
+            highlightCategory: $data->getInt('highlightCategory'),
             cleanupThreshold: $data->getInt('cleanupThreshold'),
             exportUrl: $data->getString('exportUrl'),
         );

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xEventDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xEventDocumentEnricher.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Service\Indexer\SiteKit;
+
+use Atoolo\Resource\Resource;
+use Atoolo\Search\Exception\DocumentEnrichingException;
+use Atoolo\Search\Service\Indexer\DocumentEnricher;
+use Atoolo\Search\Service\Indexer\IndexDocument;
+
+class DefaultSchema2xEventDocumentEnricher implements DocumentEnricher
+{
+    /**
+     * @throws DocumentEnrichingException
+     */
+    public function enrichDocument(
+        Resource $resource,
+        IndexDocument $doc,
+        string $processId,
+    ): IndexDocument {
+
+        $items = $resource->data->getAssociativeArray('content.items');
+
+        $main = $this->findInList($items, 'type', 'main');
+
+        $venue = $this->findInList($main['items'] ?? [], 'id', 'eventsCalendar-venue');
+        $doc = $this->addCategories($doc, $venue);
+
+        $ticketAgency = $this->findInList($main['items'] ?? [], 'id', 'eventsCalendar-ticketAgency');
+        $doc = $this->addCategories($doc, $ticketAgency);
+
+        $organizer = $this->findInList($main['items'] ?? [], 'id', 'eventsCalendar-organizer');
+        return $this->addCategories($doc, $organizer);
+    }
+
+    private function addCategories(IndexDocument $doc, array $item): IndexDocument
+    {
+        foreach ($item['model']['categories'] ?? [] as $category) {
+            if (isset($category['id'])) {
+                $doc->sp_category[] = (string) $category['id'];
+            }
+        }
+        foreach ($item['model']['categoriesPath'] ?? [] as $categoryPath) {
+            if (isset($categoryPath['id'])) {
+                $doc->sp_category_path[] = (string) $categoryPath['id'];
+            }
+        }
+
+        return $doc;
+    }
+
+    private function findInList(array $list, string $name, string $value): array
+    {
+        foreach ($list as $item) {
+            if ($item[$name] === $value) {
+                return $item;
+            }
+        }
+
+        return [];
+    }
+
+    public function cleanup(): void {}
+}

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
@@ -200,11 +200,14 @@ class DefaultSchema2xRceEventDocumentEnricher implements
             }
         }
 
-        if ($event->highlight) {
-            $doc = $this->enrichCategoryByAnchor(
-                $doc,
-                $parameter,
-                'rce.type.highlight',
+        if ($event->highlight && $parameter->highlightCategory > 0) {
+            $doc->sp_category = array_merge(
+                $doc->sp_category ?? [],
+                [(string) $parameter->highlightCategory],
+            );
+            $doc->sp_category_path = array_merge(
+                $doc->sp_category_path ?? [],
+                [(string) $parameter->highlightCategory],
             );
         }
 

--- a/test/Service/Indexer/SiteKit/DefaultSchema2xEventDocumentEnricherTest.php
+++ b/test/Service/Indexer/SiteKit/DefaultSchema2xEventDocumentEnricherTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Test\Service\Indexer\SiteKit;
+
+use Atoolo\EventsCalendar\Service\Indexer\SiteKit\DefaultSchema2xEventDocumentEnricher;
+use Atoolo\EventsCalendar\Service\Indexer\SiteKit\DefaultSchema2xRceEventDocumentEnricher;
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Search\Service\Indexer\IndexSchema2xDocument;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DefaultSchema2xEventDocumentEnricher::class)]
+class DefaultSchema2xEventDocumentEnricherTest extends TestCase
+{
+    private DefaultSchema2xEventDocumentEnricher $enricher;
+
+    public function setUp(): void
+    {
+        $this->enricher = new DefaultSchema2xEventDocumentEnricher();
+    }
+
+    public function testCleanup(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->enricher->cleanup();
+    }
+
+    public function testEnrichDocumentWithCategories(): void
+    {
+        $resource = new Resource(
+            '',
+            '123',
+            '',
+            '',
+            ResourceLanguage::default(),
+            new DataBag(['content' => ['items' => [
+                ['type' => 'main', 'items' => [
+                    ['id' => 'eventsCalendar-venue', 'model' => ['categories' => [['id' => '1']], 'categoriesPath' => [['id' => '2'],['id' => '1']]]],
+                    ['id' => 'eventsCalendar-ticketAgency', 'model' => ['categories' => [['id' => '3']], 'categoriesPath' => [['id' => '4'],['id' => '3']]]],
+                    ['id' => 'eventsCalendar-organizer', 'model' => ['categories' => [['id' => '5']], 'categoriesPath' => [['id' => '6'],['id' => '5']]]],
+                ]],
+            ]]]),
+        );
+
+        $doc = $this->enricher->enrichDocument(
+            $resource,
+            new IndexSchema2xDocument(),
+            'progress-id',
+        );
+
+        $expected = new IndexSchema2xDocument();
+        $expected->sp_category = ["1","3","5"];
+        $expected->sp_category_path = [2,1,4,3,6,5];
+
+        $this->assertEquals($expected, $doc, 'unexpected doc');
+    }
+
+    public function testEnrichDocumentWithoutCategories(): void
+    {
+        $resource = new Resource(
+            '',
+            '123',
+            '',
+            '',
+            ResourceLanguage::default(),
+            new DataBag([]),
+        );
+
+        $doc = $this->enricher->enrichDocument(
+            $resource,
+            new IndexSchema2xDocument(),
+            'progress-id',
+        );
+
+        $expected = new IndexSchema2xDocument();
+
+        $this->assertEquals($expected, $doc, 'unexpected doc');
+    }
+}

--- a/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricherTest.php
+++ b/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricherTest.php
@@ -55,6 +55,7 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
             'test',
             [$instance],
             $this->rootResources,
+            111,
             1,
             '',
         );
@@ -112,8 +113,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $expected->sp_group = 3;
         $expected->sp_group_path = [1, 2, 3];
         $expected->sp_source = ['test'];
-        $expected->sp_category = [11];
-        $expected->sp_category_path = [10, 11];
+        $expected->sp_category = [111];
+        $expected->sp_category_path = [111];
         $expected->keywords = ['keyword'];
         $expected->content =
             'location-name location-street location-zip location-city';
@@ -181,8 +182,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $fields = $enrichedDoc->getFields();
         $expected = [
             'sp_meta_string_kicker' => 'Ausstellung',
-            'sp_category' => [12, 11],
-            'sp_category_path' => [10, 12, 10, 11],
+            'sp_category' => [12, 111],
+            'sp_category_path' => [10, 12, 111],
         ];
 
         $this->assertEquals(
@@ -212,8 +213,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $fields = $enrichedDoc->getFields();
         $expected = [
-            'sp_category' => [11],
-            'sp_category_path' => [10, 11],
+            'sp_category' => [111],
+            'sp_category_path' => [111],
         ];
 
         $this->assertEquals(
@@ -247,8 +248,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $fields = $enrichedDoc->getFields();
         $expected = [
             'sp_meta_string_kicker' => 'Ausstellung',
-            'sp_category' => [13, 11],
-            'sp_category_path' => [10, 12, 13, 10, 11],
+            'sp_category' => [13, 111],
+            'sp_category_path' => [10, 12, 13, 111],
         ];
 
         $this->assertEquals(
@@ -281,8 +282,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $fields = $enrichedDoc->getFields();
         $expected = [
             'sp_meta_string_kicker' => 'Ausstellung',
-            'sp_category' => [15, 11],
-            'sp_category_path' => [10, 11],
+            'sp_category' => [15, 111],
+            'sp_category_path' => [111],
         ];
 
         $this->assertEquals(
@@ -315,8 +316,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $fields = $enrichedDoc->getFields();
         $expected = [
             'sp_meta_string_kicker' => 'Ausstellung',
-            'sp_category' => [12, 11],
-            'sp_category_path' => [10, 12, 10, 11],
+            'sp_category' => [12, 111],
+            'sp_category_path' => [10, 12, 111],
         ];
 
         $this->assertEquals(
@@ -348,8 +349,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $fields = $enrichedDoc->getFields();
         $expected = [
-            'sp_category' => [13, 11],
-            'sp_category_path' => [10, 12, 13, 10, 11],
+            'sp_category' => [13, 111],
+            'sp_category_path' => [10, 12, 13, 111],
         ];
 
         $this->assertEquals(
@@ -382,8 +383,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         $fields = $enrichedDoc->getFields();
         $expected = [
             'sp_meta_string_kicker' => 'Ausstellung',
-            'sp_category' => [14, 12, 11],
-            'sp_category_path' => [10, 14, 10, 12, 10, 11],
+            'sp_category' => [14, 12, 111],
+            'sp_category_path' => [10, 14, 10, 12, 111],
         ];
 
         $this->assertEquals(
@@ -415,8 +416,8 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $fields = $enrichedDoc->getFields();
         $expected = [
-            'sp_category' => [11, 21],
-            'sp_category_path' => [10, 11, 20, 21],
+            'sp_category' => [111, 21],
+            'sp_category_path' => [111, 20, 21],
         ];
 
         $this->assertEquals(
@@ -554,12 +555,6 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
             'type-root',
             'type-root',
         );
-        $highlight = $this->createResource(
-            '11',
-            '/category/type/highlight.php',
-            'rce.type.highlight',
-            'Highlight',
-        );
         $ausstellung = $this->createResource(
             '12',
             '/category/type/ausstellung.php',
@@ -587,14 +582,12 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
 
         $this->rootResources[] = $root->location;
         $this->resourceMap[$root->location] = $root;
-        $this->resourceMap[$highlight->location] = $highlight;
         $this->resourceMap[$ausstellung->location] = $ausstellung;
         $this->resourceMap[$filmMedien->location] = $filmMedien;
         $this->resourceMap[$konzert->location] = $konzert;
         $this->resourceMap[$noParent->location] = $noParent;
 
         $this->childrenResourceMap[$root->location] = [
-            $highlight,
             $ausstellung,
             $filmMedien,
             $konzert,
@@ -605,10 +598,6 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
         ];
 
         $this->primaryPathMap[$root->location] = [$root];
-        $this->primaryPathMap[$highlight->location] = [
-            $root,
-            $highlight,
-        ];
         $this->primaryPathMap[$ausstellung->location] = [
             $root,
             $ausstellung,


### PR DESCRIPTION
- Organizers, venues and advance booking offices are also used as categories
- the highlight category of RCE-Events is not an event type but a category of your choice