### PR TITLE
fix: creates an empty tmp-file

### DIFF
--- a/src/Service/RceEvent/RceEventListReader.php
+++ b/src/Service/RceEvent/RceEventListReader.php
@@ -120,7 +120,10 @@ class RceEventListReader
 
     private function getTmpFile(string $prefix, string $suffix): string
     {
-        return tempnam($this->getWorkDir(), $prefix) . $suffix;
+        $file = tempnam($this->getWorkDir(), $prefix);
+        $fileWithSuffix = $file .= $suffix;
+        rename($file, $fileWithSuffix);
+        return $fileWithSuffix;
     }
 
     private function getWorkDir(): string


### PR DESCRIPTION
tmpname() creates an empty file. However, this cannot be used to create a file with a suffix. In the previous implementation, an empty file without a suffix was always created. This has now been corrected.