### PR TITLE
fix: eventDates typing

### DIFF
--- a/config/graphql/decorators/EventTeaser.decorator.yaml
+++ b/config/graphql/decorators/EventTeaser.decorator.yaml
@@ -26,5 +26,5 @@ EventTeaserDecorator:
         type: "SymbolicImage"
         description: symbolic image associated with the teaser
       eventDates:
-        type: "[EventDate]"
+        type: "[EventDate!]!"
         description: event dates

--- a/src/Service/GraphQL/Resolver/Resource/ResourceEventDateResolver.php
+++ b/src/Service/GraphQL/Resolver/Resource/ResourceEventDateResolver.php
@@ -20,7 +20,7 @@ class ResourceEventDateResolver
      */
     public function getEventDates(
         Resource $resource,
-    ): ?array {
+    ): array {
         $schedulingRaws = $resource->data->getArray('metadata.schedulingRaw');
         $eventDates = [];
         foreach ($schedulingRaws as $schedulingRaw) {

--- a/src/Service/GraphQL/Resolver/Teaser/EventTeaserResolver.php
+++ b/src/Service/GraphQL/Resolver/Teaser/EventTeaserResolver.php
@@ -56,7 +56,7 @@ class EventTeaserResolver implements Resolver
     public function getEventDates(
         EventTeaser $teaser,
         ArgumentInterface $args,
-    ): ?array {
+    ): array {
         return $this->eventDateResolver
             ->getEventDates($teaser->resource);
     }


### PR DESCRIPTION
`eventDates` should always return a non-nullable array with non-nullable entries. If the event has no event dates, the array will simply be empty.