### PR TITLE
feat(ical): added endpoint that doesnt require lang & correct loation suffix handling

### DIFF
--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -31,13 +31,31 @@ final class ICalController extends AbstractController
      * @throws JsonException
      */
     #[Route(
-        '/api/ical/resource/{lang}/{location}',
+        '/api/ical/resource/{location}',
         name: 'atoolo_events_calendar_ical_location',
         methods: ['GET'],
         requirements: ['location' => '.+'],
         format: 'json',
+        priority: 1,
     )]
-    public function iCalByLocation(string $lang, string $location): Response
+    public function iCalByLocation(string $location): Response
+    {
+        $resourceLocation = $this->toResourceLocation('', $location);
+        return $this->createICalResponseByLocation($resourceLocation);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    #[Route(
+        '/api/ical/resource/{lang}/{location}',
+        name: 'atoolo_events_calendar_ical_lang_location',
+        methods: ['GET'],
+        requirements: ['location' => '.+'],
+        format: 'json',
+        priority: 2,
+    )]
+    public function iCalByLangAndLocation(string $lang, string $location): Response
     {
         $resourceLocation = $this->toResourceLocation($lang, $location);
         return $this->createICalResponseByLocation($resourceLocation);
@@ -64,12 +82,13 @@ final class ICalController extends AbstractController
 
     private function toResourceLocation(string $lang, string $path): ResourceLocation
     {
+        $suffix = str_ends_with($path, '.php') ? '' : '.php';
         if ($this->isSupportedTranslation($lang)) {
-            return ResourceLocation::of('/' . $path . '.php', ResourceLanguage::of($lang));
+            return ResourceLocation::of('/' . $path . $suffix, ResourceLanguage::of($lang));
         }
 
         if (str_starts_with($this->channel->locale, $lang . '_')) {
-            return ResourceLocation::of('/' . $path . '.php');
+            return ResourceLocation::of('/' . $path . $suffix);
         }
 
         // lang is not a language but part of the path, if not empty
@@ -77,7 +96,7 @@ final class ICalController extends AbstractController
             empty($lang)
             ? '/' . $path
             : '/' . $lang . '/' . $path
-        ) . '.php';
+        ) . $suffix;
 
         return ResourceLocation::of($location);
     }

--- a/src/Service/GraphQL/Resolver/Resource/ResourceICalUrlResolver.php
+++ b/src/Service/GraphQL/Resolver/Resource/ResourceICalUrlResolver.php
@@ -6,8 +6,6 @@ namespace Atoolo\EventsCalendar\Service\GraphQL\Resolver\Resource;
 
 use Atoolo\Resource\Resource;
 
-use function PHPUnit\Framework\isEmpty;
-
 class ResourceICalUrlResolver
 {
     public function getICalUrl(

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -51,7 +51,7 @@ class ICalControllerTest extends TestCase
         );
     }
 
-    public function testICalByLocation(): void
+    public function testICalLocation(): void
     {
         $location = 'some/location';
         $resource = $this->createResource([
@@ -67,7 +67,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarAsString')
             ->with($resource)
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLocation('de', $location);
+        $response = $this->controller->iCalByLocation($location);
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -82,7 +82,38 @@ class ICalControllerTest extends TestCase
         );
     }
 
-    public function testICalByLocationWithLanguage(): void
+    public function testICalByLangAndLocation(): void
+    {
+        $location = 'some/location';
+        $resource = $this->createResource([
+            'url' => $location,
+        ]);
+        $this->resourceLoader
+            ->expects(once())
+            ->method('load')
+            ->with(ResourceLocation::of('/' . $location . '.php'))
+            ->willReturn($resource);
+        $this->iCalFactory
+            ->expects(once())
+            ->method('createCalendarAsString')
+            ->with($resource)
+            ->willReturn('Totally valid calendar data');
+        $response = $this->controller->iCalByLangAndLocation('de', $location);
+        $this->assertEquals(
+            200,
+            $response->getStatusCode(),
+        );
+        $this->assertEquals(
+            'text/calendar',
+            $response->headers->get('Content-Type'),
+        );
+        $this->assertEquals(
+            'Totally valid calendar data',
+            $response->getContent(),
+        );
+    }
+
+    public function testICalByLangAndLocationWithLanguage(): void
     {
         $lang = 'en';
         $location = 'some/location';
@@ -100,7 +131,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarAsString')
             ->with($resource)
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLocation($lang, $location);
+        $response = $this->controller->iCalByLangAndLocation($lang, $location);
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -115,7 +146,7 @@ class ICalControllerTest extends TestCase
         );
     }
 
-    public function testICalByLocationWithoutLanguage(): void
+    public function testICalByLangAndLocationWithoutLanguage(): void
     {
         $locationA = 'some';
         $locationB = 'location';
@@ -133,7 +164,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarAsString')
             ->with($resource)
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLocation($locationA, $locationB);
+        $response = $this->controller->iCalByLangAndLocation($locationA, $locationB);
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -148,7 +179,7 @@ class ICalControllerTest extends TestCase
         );
     }
 
-    public function testICalByLocationWithEmptyLanguage(): void
+    public function testICalByLangAndLocationWithEmptyLanguage(): void
     {
         $locationA = '';
         $locationB = 'location';
@@ -166,7 +197,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarAsString')
             ->with($resource)
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLocation($locationA, $locationB);
+        $response = $this->controller->iCalByLangAndLocation($locationA, $locationB);
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -181,7 +212,7 @@ class ICalControllerTest extends TestCase
         );
     }
 
-    public function testICalByLocationNotFound(): void
+    public function testICalByLangAndLocationNotFound(): void
     {
         $location = 'some/location';
         $this->resourceLoader
@@ -192,10 +223,10 @@ class ICalControllerTest extends TestCase
                 new ResourceNotFoundException(ResourceLocation::of($location)),
             );
         $this->expectException(NotFoundHttpException::class);
-        $this->controller->iCalByLocation('de', $location);
+        $this->controller->iCalByLangAndLocation('de', $location);
     }
 
-    public function testICalByLocationInvalidResource(): void
+    public function testICalByLangAndLocationInvalidResource(): void
     {
         $location = 'some/location';
         $this->resourceLoader
@@ -206,7 +237,7 @@ class ICalControllerTest extends TestCase
                 new InvalidResourceException(ResourceLocation::of($location)),
             );
         $this->expectException(HttpException::class);
-        $this->controller->iCalByLocation('de', $location);
+        $this->controller->iCalByLangAndLocation('de', $location);
     }
 
     /**


### PR DESCRIPTION
1. Fixes an error in the `toResourceLocation(string $lang, string $path)`-method: If the `path` parameter already ends with `.php`, don't add any additional suffix
2. Besides `/api/ical/resource/{lang}/{location}` there has to be another endpoint  `/api/ical/resource/{location}`. Otherwise requests like `/api/ical/resource/index` wouldn't match. 