### PR TITLE
feat: added api endpoint /api/ical/search/{query}

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -70,6 +70,8 @@ services:
       - '@atoolo_resource.resource_channel'
       - '@atoolo_resource.resource_loader'
       - '@Atoolo\EventsCalendar\Service\ICal\ICalFactory'
+      - '@atoolo_search.search'
+      - '@serializer'
 
   # GraphQL
 

--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -78,8 +78,8 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         '/api/ical/search/{query}',
         name: 'atoolo_events_calendar_ical_search',
         methods: ['GET'],
+        requirements: ['query' => '.+'],
         format: 'json',
-        priority: 2,
     )]
     public function iCalBySearch(string $query): Response
     {

--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -12,19 +12,29 @@ use Atoolo\Resource\ResourceChannel;
 use Atoolo\Resource\ResourceLanguage;
 use Atoolo\Resource\ResourceLoader;
 use Atoolo\Resource\ResourceLocation;
+use Atoolo\Search\Dto\Search\Query\SearchQuery;
+use Atoolo\Search\Search;
 use JsonException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Serializer\SerializerInterface;
 
-final class ICalController extends AbstractController
+final class ICalController extends AbstractController implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     public function __construct(
         private readonly ResourceChannel $channel,
         private readonly ResourceLoader $loader,
         private readonly ICalFactory $iCalFactory,
+        private readonly Search $search,
+        private readonly SerializerInterface $serializer,
     ) {}
 
     /**
@@ -61,14 +71,68 @@ final class ICalController extends AbstractController
         return $this->createICalResponseByLocation($resourceLocation);
     }
 
+    /**
+     * @throws JsonException
+     */
+    #[Route(
+        '/api/ical/search/{query}',
+        name: 'atoolo_events_calendar_ical_search',
+        methods: ['GET'],
+        format: 'json',
+        priority: 2,
+    )]
+    public function iCalBySearch(string $query): Response
+    {
+        $searchQuery = $this->deserializeSearchQuery($query);
+        return $this->createICalResponseBySearchQuery($searchQuery);
+    }
+
+    private function createICalResponseBySearchQuery(SearchQuery $searchQuery): Response
+    {
+        try {
+            $resources = $this->search->search($searchQuery);
+        } catch (\Throwable $th) {
+            $this->logger?->warning(
+                'Something went wrong while exectuing the search query',
+                [
+                    'searchQuery' => $searchQuery,
+                    'exception' => $th,
+                ],
+            );
+            throw new HttpException(500, 'Something went wrong while processing the search query', $th);
+        }
+        return $this->createICalResponeByResources(...$resources);
+    }
+
+    private function deserializeSearchQuery(string $query): SearchQuery
+    {
+        try {
+            return $this->serializer->deserialize(
+                $query,
+                SearchQuery::class,
+                'json',
+            );
+        } catch (\Throwable $th) {
+            $this->logger?->warning(
+                'Something went wrong while trying to deserialize a search query.',
+                [
+                    'serializer' => $this->serializer,
+                    'query' => $query,
+                    'exception' => $th,
+                ],
+            );
+            throw new BadRequestHttpException('Invalid query \'' . $query . '\'', $th);
+        }
+    }
+
     private function createICalResponseByLocation(ResourceLocation $location): Response
     {
         try {
             $resource = $this->loader->load($location);
         } catch (ResourceNotFoundException $e) {
-            throw new NotFoundHttpException('Resource at \'' . $location . '\' not found');
+            throw new NotFoundHttpException('Resource at \'' . $location . '\' not found', $e);
         } catch (InvalidResourceException $e) {
-            throw new HttpException(500, 'Resource at \'' . $location . '\' is invalid');
+            throw new HttpException(500, 'Resource at \'' . $location . '\' is invalid', $e);
         }
         return $this->createICalResponeByResources($resource);
     }
@@ -76,7 +140,11 @@ final class ICalController extends AbstractController
     private function createICalResponeByResources(Resource ...$resources): Response
     {
         $res = new Response($this->iCalFactory->createCalendarAsString(...$resources));
+        $filename = isset($resources[0])
+            ? trim($resources[0]->data->getString('base.title', $resources[0]->name))
+            : 'ical';
         $res->headers->set('Content-Type', 'text/calendar');
+        $res->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '.ics"');
         return $res;
     }
 

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -263,7 +263,9 @@ class ICalControllerTest extends TestCase
 
     public function testICalBySearch(): void
     {
-        $resource = $this->createResource([]);
+        $resource = $this->createResource([
+            'name' => '-?some()cr4zy=?"file-name9&&',
+        ]);
         $query = json_encode([
             'filter' => [[
                 'type' => 'id',
@@ -298,6 +300,10 @@ class ICalControllerTest extends TestCase
         $this->assertEquals(
             'text/calendar',
             $response->headers->get('Content-Type'),
+        );
+        $this->assertEquals(
+            'attachment; filename="some_cr4zy_file-name9.ics"',
+            $response->headers->get('Content-Disposition'),
         );
         $this->assertEquals(
             'Totally valid calendar data',

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -15,11 +15,20 @@ use Atoolo\Resource\ResourceLanguage;
 use Atoolo\Resource\ResourceLoader;
 use Atoolo\Resource\ResourceLocation;
 use Atoolo\Resource\ResourceTenant;
+use Atoolo\Search\Dto\Search\Query\Filter\IdFilter;
+use Atoolo\Search\Dto\Search\Query\SearchQuery;
+use Atoolo\Search\Dto\Search\Query\SearchQueryBuilder;
+use Atoolo\Search\Dto\Search\Result\SearchResult;
+use Atoolo\Search\Search;
+use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\SerializerInterface;
 
 use function PHPUnit\Framework\once;
 
@@ -32,6 +41,10 @@ class ICalControllerTest extends TestCase
 
     private ICalFactory&MockObject $iCalFactory;
 
+    private Search&MockObject $search;
+
+    private SerializerInterface&MockObject $serializer;
+
     public function setUp(): void
     {
         $this->resourceLoader = $this->createMock(
@@ -39,6 +52,12 @@ class ICalControllerTest extends TestCase
         );
         $this->iCalFactory = $this->createMock(
             ICalFactory::class,
+        );
+        $this->search = $this->createMock(
+            Search::class,
+        );
+        $this->serializer = $this->createMock(
+            SerializerInterface::class,
         );
         $resourceChannel = $this->createResourceChannel([
             'locale' => 'de_DE',
@@ -48,6 +67,8 @@ class ICalControllerTest extends TestCase
             $resourceChannel,
             $this->resourceLoader,
             $this->iCalFactory,
+            $this->search,
+            $this->serializer,
         );
     }
 
@@ -238,6 +259,88 @@ class ICalControllerTest extends TestCase
             );
         $this->expectException(HttpException::class);
         $this->controller->iCalByLangAndLocation('de', $location);
+    }
+
+    public function testICalBySearch(): void
+    {
+        $resource = $this->createResource([]);
+        $query = json_encode([
+            'filter' => [[
+                'type' => 'id',
+                'values' => ['someid'],
+            ]],
+        ]);
+        $searchQuery =
+            (new SearchQueryBuilder())
+            ->filter(new IdFilter(['someid']))
+            ->build();
+        $searchResult = new SearchResult(1, 1, 1, [$resource], [], 1);
+        $this->serializer
+            ->expects(once())
+            ->method('deserialize')
+            ->with($query, SearchQuery::class, 'json')
+            ->willReturn($searchQuery);
+        $this->search
+            ->expects(once())
+            ->method('search')
+            ->with($searchQuery)
+            ->willReturn($searchResult);
+        $this->iCalFactory
+            ->expects(once())
+            ->method('createCalendarAsString')
+            ->with($resource)
+            ->willReturn('Totally valid calendar data');
+        $response = $this->controller->iCalBySearch($query);
+        $this->assertEquals(
+            200,
+            $response->getStatusCode(),
+        );
+        $this->assertEquals(
+            'text/calendar',
+            $response->headers->get('Content-Type'),
+        );
+        $this->assertEquals(
+            'Totally valid calendar data',
+            $response->getContent(),
+        );
+    }
+
+    public function testICalBySearchWithInvalidQueryString(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $query = 'invalid_query';
+        $this->serializer
+            ->expects(once())
+            ->method('deserialize')
+            ->with($query, SearchQuery::class, 'json')
+            ->willThrowException(new NotNormalizableValueException());
+        $this->controller->iCalBySearch($query);
+    }
+
+    public function testICalBySearchWithInvalidSearchQuery(): void
+    {
+        $this->expectException(HttpException::class);
+        $query = json_encode([
+            'filter' => [[
+                'type' => 'id',
+                'values' => ['someid'],
+            ]],
+        ]);
+        $searchQuery =
+            (new SearchQueryBuilder())
+            ->filter(new IdFilter(['someid']))
+            ->build();
+        $this->serializer
+            ->expects(once())
+            ->method('deserialize')
+            ->with($query, SearchQuery::class, 'json')
+            ->willReturn($searchQuery);
+        $this->search
+            ->expects(once())
+            ->method('search')
+            ->with($searchQuery)
+            ->willThrowException(new Exception());
+        $this->controller->iCalBySearch($query);
     }
 
     /**

--- a/test/Service/GraphQL/Factory/SchedulingFactoryTest.php
+++ b/test/Service/GraphQL/Factory/SchedulingFactoryTest.php
@@ -115,6 +115,18 @@ class SchedulingFactoryTest extends TestCase
         $this->assertNull($endDateTime);
     }
 
+    public function testGetEndDateTimeFromRawSchedulingInvalid()
+    {
+        $rawScheduling = [
+            "endDate" => '1640991600',
+            "endTime" => "invalid:time",
+        ];
+        $endDateTime = $this->factory->getEndDateTimeFromRawScheduling(
+            $rawScheduling,
+        );
+        $this->assertNull($endDateTime);
+    }
+
     public function testGetRRuleFromRawSchedulingEmtpy()
     {
         $this->assertNull(


### PR DESCRIPTION
- adds endpoint `/api/ical/search/{query}` that returns `.ics`-files of all resources found by the search query
  - the `query` is expected to be a `Atoolo\Search\Dto\Search\Query\SearchQuery` serialized as `json`.

usecases:
- ical feeds for search sections
- ical files for "external" resources that can only be found via a solr search