### PR TITLE
refactor(ical api): use 'query' as param instead of path for search api

### DIFF
--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -18,6 +18,7 @@ use JsonException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -75,14 +76,17 @@ final class ICalController extends AbstractController implements LoggerAwareInte
      * @throws JsonException
      */
     #[Route(
-        '/api/ical/search/{query}',
+        '/api/ical/search',
         name: 'atoolo_events_calendar_ical_search',
         methods: ['GET'],
-        requirements: ['query' => '.+'],
         format: 'json',
     )]
-    public function iCalBySearch(string $query): Response
+    public function iCalBySearch(Request $request): Response
     {
+        $query = $request->query->getString('query');
+        if (empty($query)) {
+            throw new BadRequestHttpException('query parameter \'query\' is empty');
+        }
         $searchQuery = $this->deserializeSearchQuery($query);
         return $this->createICalResponseBySearchQuery($searchQuery);
     }

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -24,6 +24,7 @@ use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -292,7 +293,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarAsString')
             ->with($resource)
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalBySearch($query);
+        $response = $this->controller->iCalBySearch(new Request(['query' => $query]));
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -311,6 +312,12 @@ class ICalControllerTest extends TestCase
         );
     }
 
+    public function testICalBySearchWithMissingQueryString(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->controller->iCalBySearch(new Request());
+    }
+
     public function testICalBySearchWithInvalidQueryString(): void
     {
         $this->expectException(BadRequestHttpException::class);
@@ -320,7 +327,7 @@ class ICalControllerTest extends TestCase
             ->method('deserialize')
             ->with($query, SearchQuery::class, 'json')
             ->willThrowException(new NotNormalizableValueException());
-        $this->controller->iCalBySearch($query);
+        $this->controller->iCalBySearch(new Request(['query' => $query]));
     }
 
     public function testICalBySearchWithInvalidSearchQuery(): void
@@ -346,7 +353,7 @@ class ICalControllerTest extends TestCase
             ->method('search')
             ->with($searchQuery)
             ->willThrowException(new Exception());
-        $this->controller->iCalBySearch($query);
+        $this->controller->iCalBySearch(new Request(['query' => $query]));
     }
 
     /**


### PR DESCRIPTION
The `query` param in the ical search API (`/api/ical/search/{query}`) should be an actual url-query-param instead of being part of the path, like so: `/api/ical/search?query={query}`.

I do this mainly for consistency and extensibility reasons. 
There's a similar API in wiesbaden for rss feeds with the route  `/api/rss/search/{location}?query={query}`. There, the `query` HAS to be a url-query-parameter, otherwise you run into route matching problems.

I think complex parameters like json-encoded search queries should probably always be actual url-query-parameters anyway.