### PR TITLE
feat: added occurence parameter to ical api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-zip": "*",
         "atoolo/graphql-search-bundle": "^1.2",
         "dragonmantank/cron-expression": "^3.3",
-        "eluceo/ical": "^2.14",
+        "eluceo/ical": "^2.15",
         "phpro/api-problem-bundle": "^1.9",
         "rlanvin/php-rrule": "^2.5",
         "soundasleep/html2text": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-zip": "*",
         "atoolo/graphql-search-bundle": "^1.2",
         "dragonmantank/cron-expression": "^3.3",
-        "eluceo/ical": "^2.15",
+        "eluceo/ical": "2.14 || 2.15",
         "phpro/api-problem-bundle": "^1.9",
         "rlanvin/php-rrule": "^2.5",
         "soundasleep/html2text": "^2.1",

--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -49,10 +49,10 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         format: 'json',
         priority: 1,
     )]
-    public function iCalByLocation(string $location, ?Request $request = null): Response
+    public function iCalByLocation(string $location, Request $request): Response
     {
         $resourceLocation = $this->toResourceLocation('', $location);
-        $atOccurrence = $request !== null ? $this->optParseOccurrence($request) : null;
+        $atOccurrence = $this->optParseOccurrence($request);
         return $this->createICalResponseByLocation($resourceLocation, $atOccurrence);
     }
 
@@ -67,10 +67,10 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         format: 'json',
         priority: 2,
     )]
-    public function iCalByLangAndLocation(string $lang, string $location, ?Request $request = null): Response
+    public function iCalByLangAndLocation(string $lang, string $location, Request $request): Response
     {
         $resourceLocation = $this->toResourceLocation($lang, $location);
-        $atOccurrence = $request !== null ? $this->optParseOccurrence($request) : null;
+        $atOccurrence = $this->optParseOccurrence($request);
         return $this->createICalResponseByLocation($resourceLocation, $atOccurrence);
     }
 

--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -49,10 +49,11 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         format: 'json',
         priority: 1,
     )]
-    public function iCalByLocation(string $location): Response
+    public function iCalByLocation(string $location, ?Request $request = null): Response
     {
         $resourceLocation = $this->toResourceLocation('', $location);
-        return $this->createICalResponseByLocation($resourceLocation);
+        $atOccurrence = $request !== null ? $this->optParseOccurrence($request) : null;
+        return $this->createICalResponseByLocation($resourceLocation, $atOccurrence);
     }
 
     /**
@@ -66,10 +67,11 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         format: 'json',
         priority: 2,
     )]
-    public function iCalByLangAndLocation(string $lang, string $location): Response
+    public function iCalByLangAndLocation(string $lang, string $location, ?Request $request = null): Response
     {
         $resourceLocation = $this->toResourceLocation($lang, $location);
-        return $this->createICalResponseByLocation($resourceLocation);
+        $atOccurrence = $request !== null ? $this->optParseOccurrence($request) : null;
+        return $this->createICalResponseByLocation($resourceLocation, $atOccurrence);
     }
 
     /**
@@ -87,14 +89,31 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         if (empty($query)) {
             throw new BadRequestHttpException('query parameter \'query\' is empty');
         }
+        $atOccurrence = $this->optParseOccurrence($request);
         $searchQuery = $this->deserializeSearchQuery($query);
-        return $this->createICalResponseBySearchQuery($searchQuery);
+        return $this->createICalResponseBySearchQuery($searchQuery, $atOccurrence);
     }
 
-    private function createICalResponseBySearchQuery(SearchQuery $searchQuery): Response
+    private function optParseOccurrence(Request $request): ?\DateTime
+    {
+        $occurrenceRaw = $request->query->getString('occurrence');
+        if (!empty($occurrenceRaw)) {
+            try {
+                return new \DateTime($occurrenceRaw);
+            } catch (\Throwable $th) {
+                throw new BadRequestHttpException(
+                    'optional parameter \'occurrence\' could not be parsed to a DateTime object',
+                    $th,
+                );
+            }
+        }
+        return null;
+    }
+
+    private function createICalResponseBySearchQuery(SearchQuery $searchQuery, ?\DateTime $atOccurrence = null): Response
     {
         try {
-            $resources = $this->search->search($searchQuery);
+            $searchResult = $this->search->search($searchQuery);
         } catch (\Throwable $th) {
             $this->logger?->warning(
                 'Something went wrong while exectuing the search query',
@@ -105,7 +124,7 @@ final class ICalController extends AbstractController implements LoggerAwareInte
             );
             throw new HttpException(500, 'Something went wrong while processing the search query', $th);
         }
-        return $this->createICalResponeByResources(...$resources);
+        return $this->createICalResponeByResources($searchResult->results, $atOccurrence);
     }
 
     private function deserializeSearchQuery(string $query): SearchQuery
@@ -129,7 +148,7 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         }
     }
 
-    private function createICalResponseByLocation(ResourceLocation $location): Response
+    private function createICalResponseByLocation(ResourceLocation $location, ?\DateTime $atOccurrence = null): Response
     {
         try {
             $resource = $this->loader->load($location);
@@ -138,14 +157,17 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         } catch (InvalidResourceException $e) {
             throw new HttpException(500, 'Resource at \'' . $location . '\' is invalid', $e);
         }
-        return $this->createICalResponeByResources($resource);
+        return $this->createICalResponeByResources([$resource], $atOccurrence);
     }
 
-    private function createICalResponeByResources(Resource ...$resources): Response
+    /**
+     * @param Resource[] $resources
+     */
+    private function createICalResponeByResources(array $resources, ?\DateTime $atOccurrence = null): Response
     {
-        $res = new Response($this->iCalFactory->createCalendarAsString(...$resources));
+        $res = new Response($this->iCalFactory->createCalendarFromResourcesAsString($resources, $atOccurrence));
         $filename = 'ical';
-        if (isset($resources[0])) {
+        if (count($resources) === 1) {
             $sanitizedName = $this->sanitizeFilename($resources[0]->name);
             $filename = !empty($sanitizedName) ? $sanitizedName : $filename;
         }

--- a/src/Dto/Scheduling/SchedulingBuilder.php
+++ b/src/Dto/Scheduling/SchedulingBuilder.php
@@ -45,7 +45,7 @@ class SchedulingBuilder
 
     /**
      * @param bool $keepRelativeEnd if true, the end date is changed such that the
-     * previous time difference between start and end is preservces. If false, the end
+     * previous time difference between start and end is preserved. If false, the end
      * date remains unchanged
      */
     public function setStart(DateTime $start, bool $keepRelativeEnd = false): self
@@ -53,9 +53,7 @@ class SchedulingBuilder
         if ($this->end !== null && $keepRelativeEnd) {
             $prevStartEndDiff =  $this->end->getTimestamp() - $this->start->getTimestamp();
             $this->setEnd(
-                (new \DateTime())->setTimestamp(
-                    $start->getTimestamp() + $prevStartEndDiff,
-                ),
+                (clone $start)->setTimestamp($start->getTimestamp() + $prevStartEndDiff),
             );
         }
         $this->start = $start;

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -86,10 +86,13 @@ class ICalControllerTest extends TestCase
             ->willReturn($resource);
         $this->iCalFactory
             ->expects(once())
-            ->method('createCalendarAsString')
-            ->with($resource)
+            ->method('createCalendarFromResourcesAsString')
+            ->with([$resource])
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLocation($location);
+        $response = $this->controller->iCalByLocation(
+            $location,
+            new Request(['occurrence' => '21.03.2025 12:00']),
+        );
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -117,10 +120,14 @@ class ICalControllerTest extends TestCase
             ->willReturn($resource);
         $this->iCalFactory
             ->expects(once())
-            ->method('createCalendarAsString')
-            ->with($resource)
+            ->method('createCalendarFromResourcesAsString')
+            ->with([$resource])
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLangAndLocation('de', $location);
+        $response = $this->controller->iCalByLangAndLocation(
+            'de',
+            $location,
+            new Request(['occurrence' => '21.03.2025 12:00']),
+        );
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -150,8 +157,8 @@ class ICalControllerTest extends TestCase
             ->willReturn($resource);
         $this->iCalFactory
             ->expects(once())
-            ->method('createCalendarAsString')
-            ->with($resource)
+            ->method('createCalendarFromResourcesAsString')
+            ->with([$resource])
             ->willReturn('Totally valid calendar data');
         $response = $this->controller->iCalByLangAndLocation($lang, $location);
         $this->assertEquals(
@@ -183,8 +190,8 @@ class ICalControllerTest extends TestCase
             ->willReturn($resource);
         $this->iCalFactory
             ->expects(once())
-            ->method('createCalendarAsString')
-            ->with($resource)
+            ->method('createCalendarFromResourcesAsString')
+            ->with([$resource])
             ->willReturn('Totally valid calendar data');
         $response = $this->controller->iCalByLangAndLocation($locationA, $locationB);
         $this->assertEquals(
@@ -216,8 +223,8 @@ class ICalControllerTest extends TestCase
             ->willReturn($resource);
         $this->iCalFactory
             ->expects(once())
-            ->method('createCalendarAsString')
-            ->with($resource)
+            ->method('createCalendarFromResourcesAsString')
+            ->with([$resource])
             ->willReturn('Totally valid calendar data');
         $response = $this->controller->iCalByLangAndLocation($locationA, $locationB);
         $this->assertEquals(
@@ -277,7 +284,7 @@ class ICalControllerTest extends TestCase
             (new SearchQueryBuilder())
             ->filter(new IdFilter(['someid']))
             ->build();
-        $searchResult = new SearchResult(1, 1, 1, [$resource], [], null, 1);
+        $searchResult = new SearchResult(1, 1, 1, [$resource], [], 1);
         $this->serializer
             ->expects(once())
             ->method('deserialize')
@@ -290,10 +297,12 @@ class ICalControllerTest extends TestCase
             ->willReturn($searchResult);
         $this->iCalFactory
             ->expects(once())
-            ->method('createCalendarAsString')
-            ->with($resource)
+            ->method('createCalendarFromResourcesAsString')
+            ->with([$resource])
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalBySearch(new Request(['query' => $query]));
+        $response = $this->controller->iCalBySearch(
+            new Request(['query' => $query, 'occurrence' => '21.03.2025 12:00']),
+        );
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -316,6 +325,13 @@ class ICalControllerTest extends TestCase
     {
         $this->expectException(BadRequestHttpException::class);
         $this->controller->iCalBySearch(new Request());
+    }
+
+    public function testICalBySearchWithInvalidOccurrenceDate(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $query = json_encode(['text' => 'valid_query']);
+        $this->controller->iCalBySearch(new Request(['query' => $query, 'occurrence' => 'inv4l1d_da7e']));
     }
 
     public function testICalBySearchWithInvalidQueryString(): void

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -160,7 +160,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarFromResourcesAsString')
             ->with([$resource])
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLangAndLocation($lang, $location);
+        $response = $this->controller->iCalByLangAndLocation($lang, $location, new Request());
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -193,7 +193,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarFromResourcesAsString')
             ->with([$resource])
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLangAndLocation($locationA, $locationB);
+        $response = $this->controller->iCalByLangAndLocation($locationA, $locationB, new Request());
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -226,7 +226,7 @@ class ICalControllerTest extends TestCase
             ->method('createCalendarFromResourcesAsString')
             ->with([$resource])
             ->willReturn('Totally valid calendar data');
-        $response = $this->controller->iCalByLangAndLocation($locationA, $locationB);
+        $response = $this->controller->iCalByLangAndLocation($locationA, $locationB, new Request());
         $this->assertEquals(
             200,
             $response->getStatusCode(),
@@ -252,7 +252,7 @@ class ICalControllerTest extends TestCase
                 new ResourceNotFoundException(ResourceLocation::of($location)),
             );
         $this->expectException(NotFoundHttpException::class);
-        $this->controller->iCalByLangAndLocation('de', $location);
+        $this->controller->iCalByLangAndLocation('de', $location, new Request());
     }
 
     public function testICalByLangAndLocationInvalidResource(): void
@@ -266,7 +266,7 @@ class ICalControllerTest extends TestCase
                 new InvalidResourceException(ResourceLocation::of($location)),
             );
         $this->expectException(HttpException::class);
-        $this->controller->iCalByLangAndLocation('de', $location);
+        $this->controller->iCalByLangAndLocation('de', $location, new Request());
     }
 
     public function testICalBySearch(): void

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -284,7 +284,7 @@ class ICalControllerTest extends TestCase
             (new SearchQueryBuilder())
             ->filter(new IdFilter(['someid']))
             ->build();
-        $searchResult = new SearchResult(1, 1, 1, [$resource], [], 1);
+        $searchResult = new SearchResult(1, 1, 1, [$resource], [], null, 1);
         $this->serializer
             ->expects(once())
             ->method('deserialize')

--- a/test/Service/GraphQL/Factory/SchedulingFactoryTest.php
+++ b/test/Service/GraphQL/Factory/SchedulingFactoryTest.php
@@ -231,7 +231,7 @@ class SchedulingFactoryTest extends TestCase
     /**
      * Alle 6 Monate, jeden 2. Freitag, bis 01.01.2025 00:00
      */
-    public function testGetRRuleFromRawSchedulingMonthlyByOccurenceUntil()
+    public function testGetRRuleFromRawSchedulingMonthlyByOccurrenceUntil()
     {
         $actual = $this->factory->getRRuleFromRawScheduling([
             "type" => "monthlyByOccurrence",
@@ -269,7 +269,7 @@ class SchedulingFactoryTest extends TestCase
     /**
      * Jedes 2. Jahr, jeden 3. Sonntag im März, bis 01.01.2025 00:00
      */
-    public function testGetRRuleFromRawSchedulingYearlyByOccurenceUntil()
+    public function testGetRRuleFromRawSchedulingYearlyByOccurrenceUntil()
     {
         $actual = $this->factory->getRRuleFromRawScheduling([
             "type" => "yearlyByOccurrence",

--- a/test/Service/Scheduling/SchedulingManagerTest.php
+++ b/test/Service/Scheduling/SchedulingManagerTest.php
@@ -516,4 +516,100 @@ class SchedulingManagerTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->schedulingManager->getAllOccurrencesOfSchedulings($schedulings);
     }
+
+    public function testFindOccurrenceSingleScheduling(): void
+    {
+        $scheduling = new Scheduling(
+            new \DateTime('02.02.2025 12:00'),
+            new \DateTime('02.02.2025 22:00'),
+            false,
+            true,
+            true,
+            'FREQ=WEEKLY;INTERVAL=1;COUNT=2',
+        );
+        $this->assertEquals(
+            new Scheduling(
+                new \DateTime('09.02.2025 12:00'),
+                new \DateTime('09.02.2025 22:00'),
+                false,
+                true,
+                true,
+                null,
+            ),
+            $this->schedulingManager->findOccurrenceOfScheduling($scheduling, new \DateTime('09.02.2025 12:00')),
+        );
+    }
+
+    public function testFindOccurrenceSingleSchedulingNotFound(): void
+    {
+        $scheduling = new Scheduling(
+            new \DateTime('02.02.2025 12:00'),
+            new \DateTime('02.02.2025 22:00'),
+            false,
+            true,
+            true,
+            'FREQ=WEEKLY;INTERVAL=1;COUNT=2',
+        );
+        $this->assertNull(
+            $this->schedulingManager->findOccurrenceOfScheduling($scheduling, new \DateTime('06.02.2025 12:00')),
+        );
+    }
+
+    public function testFindOccurrenceMultipleSchedulings(): void
+    {
+        $schedulings = [
+            new Scheduling(
+                new \DateTime('02.02.2025 12:00'),
+                new \DateTime('02.02.2025 22:00'),
+                false,
+                true,
+                true,
+                'FREQ=WEEKLY;INTERVAL=1;COUNT=2',
+            ),
+            new Scheduling(
+                new \DateTime('17.03.2025 14:00'),
+                new \DateTime('17.03.2025 20:00'),
+                false,
+                true,
+                true,
+                'FREQ=DAILY;INTERVAL=1;COUNT=10',
+            ),
+        ];
+        $this->assertEquals(
+            new Scheduling(
+                new \DateTime('20.03.2025 14:00'),
+                new \DateTime('20.03.2025 20:00'),
+                false,
+                true,
+                true,
+                null,
+            ),
+            $this->schedulingManager->findOccurrenceOfSchedulings($schedulings, new \DateTime('20.03.2025 14:00')),
+        );
+    }
+
+    public function testFindOccurrenceMultipleSchedulingsNotFound(): void
+    {
+        $schedulings = [
+            new Scheduling(
+                new \DateTime('02.02.2025 12:00'),
+                new \DateTime('02.02.2025 22:00'),
+                false,
+                true,
+                true,
+                'FREQ=WEEKLY;INTERVAL=1;COUNT=2',
+            ),
+            new Scheduling(
+                new \DateTime('17.03.2025 14:00'),
+                new \DateTime('17.03.2025 20:00'),
+                false,
+                true,
+                true,
+                'FREQ=DAILY;INTERVAL=1;COUNT=10',
+            ),
+        ];
+        $this->assertNull(
+            $this->schedulingManager->findOccurrenceOfSchedulings($schedulings, new \DateTime('04.10.2024 12:00')),
+        );
+    }
 }


### PR DESCRIPTION
Added optional query parameter `occurrence` to all ical endpoints, which can be used to target a specific occurrence of a resource with scheduling. Otherwise all occurrences will be returned (current behavior).

