### PR TITLE
fix: ical filename sanitization

### DIFF
--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -188,7 +188,8 @@ final class ICalController extends AbstractController implements LoggerAwareInte
 
     /**
      * Returns a filename and a filename fallback as expected by
-     * `\Symfony\Component\HttpFoundation\ResponseHeaderBag::makeDisposition`
+     * `\Symfony\Component\HttpFoundation\HeaderUtils::makeDisposition`
+     *
      * @return array{string, string}
      */
     private function toFilenameAndFilenameFallback(string $original): array
@@ -196,14 +197,10 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         // strip path separators
         $filename = preg_replace('/[\\\\\/]+/', '', $original) ?? '';
 
-        // strip path separators , replace umlaute and ß, strip non-ascii and % in filename fallback
-        $filenameFallback = preg_replace('/[\\\\\/]+/', '', $original) ?? '';
-        $filenameFallback = str_replace(
-            ['ä', 'ö', 'ü', 'Ä', 'Ö', 'Ü', 'ß'],
-            ['ae', 'oe', 'ue', 'Ae', 'Oe', 'Ue', 'ss'],
-            $filenameFallback,
-        );
-        $filenameFallback = preg_replace('/[^[:ascii:]]+|%+/', '', $filenameFallback) ?? '';
+        // strip path separators and %, replace chars to ascii in filename fallback
+        $filenameFallback = preg_replace('/[\\\\\/%]+/', '', $original) ?? '';
+        $filenameFallback = transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $filenameFallback);
+        ;
         return [$filename, $filenameFallback];
     }
 

--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -164,9 +164,6 @@ final class ICalController extends AbstractController implements LoggerAwareInte
     /**
      * @param Resource[] $resources
      */
-    /**
-     * @param Resource[] $resources
-     */
     private function createICalResponeByResources(array $resources, ?\DateTime $atOccurrence = null): Response
     {
         $res = new Response($this->iCalFactory->createCalendarFromResourcesAsString($resources, $atOccurrence));

--- a/src/Controller/ICalController.php
+++ b/src/Controller/ICalController.php
@@ -200,7 +200,7 @@ final class ICalController extends AbstractController implements LoggerAwareInte
         // strip path separators and %, replace chars to ascii in filename fallback
         $filenameFallback = preg_replace('/[\\\\\/%]+/', '', $original) ?? '';
         $filenameFallback = transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $filenameFallback);
-        ;
+
         return [$filename, $filenameFallback];
     }
 

--- a/test/Controller/ICalControllerTest.php
+++ b/test/Controller/ICalControllerTest.php
@@ -272,7 +272,7 @@ class ICalControllerTest extends TestCase
     public function testICalBySearch(): void
     {
         $resource = $this->createResource([
-            'name' => '-?some()cr4zy=?"file-name9&&',
+            'name' => '-?some()cr4zy=?"file\\-name/9&&',
         ]);
         $query = json_encode([
             'filter' => [[
@@ -312,7 +312,7 @@ class ICalControllerTest extends TestCase
             $response->headers->get('Content-Type'),
         );
         $this->assertEquals(
-            'attachment; filename="some_cr4zy_file-name9.ics"',
+            'attachment; filename="-?some()cr4zy=?\"file-name9&&.ics"',
             $response->headers->get('Content-Disposition'),
         );
         $this->assertEquals(


### PR DESCRIPTION
Simplify filename sanitization by using the `Symfony\Component\HttpFoundation\ResponseHeaderBag::makeDisposition` and `Symfony\Component\HttpFoundation\HeaderUtils`.