### PR TITLE
feat: skip blacklisted rce event dates during indexing

### DIFF
--- a/src/Service/Indexer/RceEventIndexerDateFilter.php
+++ b/src/Service/Indexer/RceEventIndexerDateFilter.php
@@ -24,6 +24,6 @@ class RceEventIndexerDateFilter implements RceEventIndexerFilter
         RceEventListItem $event,
         RceEventDate $eventDate,
     ): bool {
-        return $eventDate->startDate >= $this->date;
+        return !$eventDate->blacklisted && $eventDate->startDate >= $this->date;
     }
 }

--- a/test/Service/Indexer/RceEventIndexerDateFilterTest.php
+++ b/test/Service/Indexer/RceEventIndexerDateFilterTest.php
@@ -59,4 +59,26 @@ class RceEventIndexerDateFilterTest extends TestCase
             'Event should be accepted',
         );
     }
+
+    public function testWithBlacklistedtDate(): void
+    {
+        $filter = new RceEventIndexerDateFilter();
+
+        $now = new DateTime();
+        $event = $this->createStub(RceEventListItem::class);
+        $eventDate  = new RceEventDate(
+            hashId: '',
+            startDate: $now,
+            endDate: $now,
+            blacklisted: true,
+            soldOut: false,
+            cancelled: false,
+            postponed: false,
+        );
+
+        $this->assertFalse(
+            $filter->accept($event, $eventDate),
+            'Event should not be accepted',
+        );
+    }
 }


### PR DESCRIPTION
If an RCE event date has the attribute `blacklisted` set to `true`, it should be skipped by the indexer.

This restores the behaviour of the [sitekit events calendar implementation](https://gitlab.sitepark.com/sitekit/events-calendar-php/-/blob/main/php/SP/EventsCalendar/ComponentModel/RceEvent/XmlImport.php?ref_type=heads#L507).