### PR TITLE
feat(rce): added venue category mapping for rce indexer

### DIFF
--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
@@ -222,15 +222,21 @@ class DefaultSchema2xRceEventDocumentEnricher implements
             );
         }
 
-        if (
-            $event->addresses->location !== null &&
-            $event->addresses->location->gemkey !== null
-        ) {
-            $doc = $this->enrichCategoryByAnchor(
-                $doc,
-                $parameter,
-                'rce.gemkey.' . $event->addresses->location->gemkey,
-            );
+        if ($event->addresses->location !== null) {
+            if ($event->addresses->location->gemkey !== null) {
+                $doc = $this->enrichCategoryByAnchor(
+                    $doc,
+                    $parameter,
+                    'rce.gemkey.' . $event->addresses->location->gemkey,
+                );
+            }
+            if ($event->addresses->location->name !== null) {
+                $doc = $this->enrichCategoryByAnchor(
+                    $doc,
+                    $parameter,
+                    'rce.venue.' . $this->stringToAnchor($event->addresses->location->name),
+                );
+            }
         }
 
         if (
@@ -245,6 +251,17 @@ class DefaultSchema2xRceEventDocumentEnricher implements
         }
 
         return $doc;
+    }
+
+    private function stringToAnchor(string $s): string
+    {
+        $anchor = strtolower($s);
+        $anchor = str_replace(['ä', 'ö', 'ü'], ['ae', 'oe', 'ue'], $anchor);
+        /** @var string $anchor */
+        $anchor = preg_replace('/[^a-z0-9]+/', '-', $anchor);
+        /** @var string $anchor */
+        $anchor = preg_replace('/-+$|^-+/', '', $anchor);
+        return $anchor;
     }
 
     /**


### PR DESCRIPTION
Similar to the other RCE categories ("Gremien", "Quellen"), RCE venues can be categories in the CMS now. They have the anchor prefix `rce.venue.`. This category tree can now be passed to the indexer, which can then lookup the category id for each event venue and pass it into the `sp_category` field.

@hyra-soe I'll pass this PR to you since Holger is on vacation

Refs: [#36080](https://redmine.sitepark.com/issues/36080)