### PR TITLE
feat(rce): replace "highlightCategory" with "simpleCategoryMap" for rce imports

### DIFF
--- a/src/Dto/Indexer/RceEventIndexerParameter.php
+++ b/src/Dto/Indexer/RceEventIndexerParameter.php
@@ -12,12 +12,13 @@ class RceEventIndexerParameter
     /**
      * @param array<RceEventIndexerInstance> $instanceList
      * @param array<string> $categoryRootResourceLocations
+     * @param array<string,array<int,int>> $simpleCategoryMap
      */
     public function __construct(
         public readonly string $source,
         public readonly array $instanceList,
         public readonly array $categoryRootResourceLocations,
-        public readonly int $highlightCategory,
+        public readonly array $simpleCategoryMap,
         public readonly int $cleanupThreshold,
         public readonly string $exportUrl,
     ) {}

--- a/src/Service/Indexer/RceEventIndexer.php
+++ b/src/Service/Indexer/RceEventIndexer.php
@@ -146,11 +146,18 @@ class RceEventIndexer extends AbstractIndexer
             );
         }
 
+        /** @var array<string,array<int,int>> $simpleCategoryMap */
+        $simpleCategoryMap = $data->getAssociativeArray('simpleCategoryMap');
+        // for backward compatibility
+        $highlightCategory = $data->getInt('highlightCategory', -1);
+        if ($highlightCategory !== -1 && !isset($simpleCategoryMap['highlight'])) {
+            $simpleCategoryMap['highlight'] = [$highlightCategory];
+        }
         return new RceEventIndexerParameter(
             source: $this->source,
             instanceList: $instanceList,
             categoryRootResourceLocations: $categoryRootResourceLocations,
-            highlightCategory: $data->getInt('highlightCategory'),
+            simpleCategoryMap: $simpleCategoryMap,
             cleanupThreshold: $data->getInt('cleanupThreshold'),
             exportUrl: $data->getString('exportUrl'),
         );

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricher.php
@@ -203,14 +203,18 @@ class DefaultSchema2xRceEventDocumentEnricher implements
             }
         }
 
-        if ($event->highlight && $parameter->highlightCategory > 0) {
+        if ($event->highlight && !empty($parameter->simpleCategoryMap['highlight'] ?? [])) {
+            $highlightCategoryIdsAsStrings = array_map(
+                fn($id) => (string) $id,
+                $parameter->simpleCategoryMap['highlight'],
+            );
             $doc->sp_category = array_merge(
                 $doc->sp_category ?? [],
-                [(string) $parameter->highlightCategory],
+                $highlightCategoryIdsAsStrings,
             );
             $doc->sp_category_path = array_merge(
                 $doc->sp_category_path ?? [],
-                [(string) $parameter->highlightCategory],
+                $highlightCategoryIdsAsStrings,
             );
         }
 

--- a/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricherTest.php
+++ b/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventDocumentEnricherTest.php
@@ -55,7 +55,9 @@ class DefaultSchema2xRceEventDocumentEnricherTest extends TestCase
             'test',
             [$instance],
             $this->rootResources,
-            111,
+            [
+                'highlight' => [111],
+            ],
             1,
             '',
         );


### PR DESCRIPTION
Currently, the `RceEventIndexerParameter` has the property `highlighCategory`. This informs the rce indexer which category id to add into the solr fields `sp_category`/`sp_category_path` if an rce event has the attribute "highlighted".  

The changes in this PR replace the `highlighCategory` property with a more general `simpleCategoryMap` property. The  `simpleCategoryMap` is an associative array that takes keys, e.g. "highlight", and maps them to one or multiple category ids. The logic of how each key should be interpreted can be implemented on a customer basis. For now, the `DefaultSchema2xRceEventDocumentEnricher` only recognizes the key "highlight".

So if a indexer config would have looked like this before:
```php
[
  "data" => [
     ....
     "highlightCategory" => 6421
  ]
]
```

it would now look like this:
```php
[
  "data" => [
     ....
    "simpleCategoryMap" => [
       "highlight" => [6421]
    ],
  ]
]
```

I also respected backward compatibility, so if there's a config which still uses `highlightCategory`, it will automatically be converted into the new `simpleCategoryMap`