### PR TITLE
feat(rce): generate kicker from categories in rce indexer

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -17,6 +17,12 @@ services:
     tags:
       - { name: 'atoolo_events_calendar.indexer.rceEventDocumentEnricher.schema2x', priority: 100 }
 
+  Atoolo\EventsCalendar\Service\Indexer\SiteKit\DefaultSchema2xRceEventCategoryDocumentEnricher:
+    arguments:
+      - '@atoolo_resource.category_hierarchy_loader'
+    tags:
+      - { name: 'atoolo_events_calendar.indexer.rceEventDocumentEnricher.schema2x', priority: 90 }
+
   atoolo_events_calendar.indexer.rceEventAborter:
     class: Atoolo\Search\Service\Indexer\IndexingAborter
     arguments:

--- a/src/Dto/Indexer/RceEventIndexerInstance.php
+++ b/src/Dto/Indexer/RceEventIndexerInstance.php
@@ -17,5 +17,6 @@ class RceEventIndexerInstance
         public readonly string $detailPageUrl,
         public readonly int $group,
         public readonly array $groupPath,
+        public readonly ?string $kickerCategoryResourceLocation = null,
     ) {}
 }

--- a/src/Service/Indexer/RceEventIndexer.php
+++ b/src/Service/Indexer/RceEventIndexer.php
@@ -134,7 +134,8 @@ class RceEventIndexer extends AbstractIndexer
          *     id:int,
          *     detailPageUrl: string,
          *     group:int,
-         *     groupPath: array<int>
+         *     groupPath: array<int>,
+         *     kickerCategoryResourceLocation: ?string
          * } $instance
          */
         foreach ($data->getArray('instanceList') as $instance) {
@@ -143,6 +144,7 @@ class RceEventIndexer extends AbstractIndexer
                 $instance['detailPageUrl'],
                 $instance['group'],
                 $instance['groupPath'],
+                $instance['kickerCategoryResourceLocation'] ?? null,
             );
         }
 

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricher.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Service\Indexer\SiteKit;
+
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerInstance;
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerParameter;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
+use Atoolo\EventsCalendar\Service\Indexer\RceEventDocumentEnricher;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceHierarchyWalker;
+use Atoolo\Resource\ResourceLocation;
+use Atoolo\Search\Service\Indexer\IndexDocument;
+use Atoolo\Search\Service\Indexer\IndexSchema2xDocument;
+
+/**
+ * @implements RceEventDocumentEnricher<IndexSchema2xDocument>
+ */
+class DefaultSchema2xRceEventCategoryDocumentEnricher implements
+    RceEventDocumentEnricher
+{
+    /**
+     * @var array<string,array<string,string>>
+     */
+    private array $collectChildIdNameMapCache = [];
+
+    public function __construct(
+        private readonly ResourceHierarchyLoader $categoryLoader,
+    ) {}
+
+    public function cleanup(): void
+    {
+        $this->categoryLoader->cleanup();
+        $this->collectChildIdNameMapCache = [];
+    }
+
+    public function enrichDocument(
+        RceEventIndexerParameter $parameter,
+        RceEventIndexerInstance $instance,
+        RceEventListItem $event,
+        RceEventDate $eventDate,
+        IndexDocument $doc,
+        string $processId,
+    ): IndexDocument {
+
+        if ($instance->kickerCategoryResourceLocation !== null && !empty($doc->sp_category)) {
+            $kickerCategoryChildIdNameMap = $this->collectChildIdNameMap(
+                ResourceLocation::of($instance->kickerCategoryResourceLocation),
+            );
+            $kickerStrings = [];
+            foreach ($doc->sp_category as $category) {
+                if (isset($kickerCategoryChildIdNameMap[$category])) {
+                    $kickerStrings[] = $kickerCategoryChildIdNameMap[$category];
+                }
+            }
+            if (!empty($kickerStrings)) {
+                $doc->setMetaString('kicker', implode(' | ', $kickerStrings));
+            }
+        }
+
+        return $doc;
+    }
+
+    /**
+     * collects all children of a resource (recursively!) and creates a map,
+     * mapping their id to their name
+     *
+     * @return array<string,string>
+     */
+    private function collectChildIdNameMap(
+        ResourceLocation $root,
+    ): array {
+        if (!isset($this->collectChildIdNameMapCache[$root->location])) {
+            /** @var array<string,string> $childIdNameMap */
+            $childIdNameMap = [];
+            $walker = new ResourceHierarchyWalker($this->categoryLoader);
+            $walker->walk(
+                $root,
+                function ($resource) use (&$childIdNameMap) {
+                    $childIdNameMap[$resource->id] = $resource->data->getString('base.title');
+                },
+            );
+            $this->collectChildIdNameMapCache[$root->location] = $childIdNameMap;
+            print_r($childIdNameMap);
+        }
+        return $this->collectChildIdNameMapCache[$root->location];
+    }
+}

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricher.php
@@ -56,7 +56,10 @@ class DefaultSchema2xRceEventCategoryDocumentEnricher implements
                 }
             }
             if (!empty($kickerStrings)) {
-                $doc->setMetaString('kicker', implode(' | ', $kickerStrings));
+                $kicker =  implode(' | ', $kickerStrings);
+                $doc->setMetaString('kicker', $kicker);
+                // also add kicker to content to it's searchable
+                $doc->content = ($doc->content ?? '') . ' ' . $kicker;
             }
         }
 

--- a/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricher.php
+++ b/src/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricher.php
@@ -83,7 +83,6 @@ class DefaultSchema2xRceEventCategoryDocumentEnricher implements
                 },
             );
             $this->collectChildIdNameMapCache[$root->location] = $childIdNameMap;
-            print_r($childIdNameMap);
         }
         return $this->collectChildIdNameMapCache[$root->location];
     }

--- a/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricherTest.php
+++ b/test/Service/Indexer/SiteKit/DefaultSchema2xRceEventCategoryDocumentEnricherTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\EventsCalendar\Test\Service\Indexer\SiteKit;
+
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerInstance;
+use Atoolo\EventsCalendar\Dto\Indexer\RceEventIndexerParameter;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventAddress;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventAddresses;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventSource;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventTheme;
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventUpload;
+use Atoolo\EventsCalendar\Service\Indexer\SiteKit\DefaultSchema2xRceEventCategoryDocumentEnricher;
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\Resource;
+use Atoolo\Resource\ResourceHierarchyLoader;
+use Atoolo\Resource\ResourceLanguage;
+use Atoolo\Resource\ResourceLocation;
+use Atoolo\Search\Service\Indexer\IndexSchema2xDocument;
+use DateTime;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DefaultSchema2xRceEventCategoryDocumentEnricher::class)]
+class DefaultSchema2xRceEventCategoryDocumentEnricherTest extends TestCase
+{
+    private ?string $kickerCategoryResourceLocation = null;
+
+    private array $resourceMap = [];
+
+    private array $childrenResourceMap = [];
+
+    private array $primaryPathMap = [];
+
+    private DefaultSchema2xRceEventCategoryDocumentEnricher $enricher;
+
+    private RceEventIndexerParameter $parameter;
+
+    public function setUp(): void
+    {
+        $loader = $this->createHierarchyLoader();
+
+        $instance = new RceEventIndexerInstance(
+            1,
+            'https://www.example.com/details.php',
+            3,
+            [1, 2, 3],
+            $this->kickerCategoryResourceLocation,
+        );
+        $this->parameter = new RceEventIndexerParameter(
+            'test',
+            [$instance],
+            [],
+            [
+                'highlight' => [111],
+            ],
+            1,
+            '',
+        );
+
+        $this->enricher = new DefaultSchema2xRceEventCategoryDocumentEnricher($loader);
+    }
+
+    public function testCleanUp(): void
+    {
+        $loader = $this->createMock(ResourceHierarchyLoader::class);
+        $loader->expects($this->once())
+            ->method('cleanup');
+
+        $enricher = new DefaultSchema2xRceEventCategoryDocumentEnricher($loader);
+        $enricher->cleanUp();
+    }
+
+    public function testEnrichDocument(): void
+    {
+        $event = $this->createEvent();
+        $doc = new IndexSchema2xDocument();
+        $doc->sp_category = ['11', '12'];
+        $enrichedDoc = $this->enricher->enrichDocument(
+            $this->parameter,
+            $this->parameter->instanceList[0],
+            $event,
+            $event->dates[0],
+            $doc,
+            'process-id',
+        );
+
+        $this->assertEquals(
+            'some-category-a | some-category-b',
+            $enrichedDoc->getFields()['sp_meta_string_kicker'],
+            'Document should be enriched with the correct data.',
+        );
+    }
+
+    public function createEvent(): RceEventListItem
+    {
+        $eventDate = new RceEventDate(
+            'hash',
+            new DateTime(),
+            new DateTime(),
+            false,
+            true,
+            true,
+            true,
+        );
+        $addresses = new RceEventAddresses(
+            new RceEventAddress(
+                'location-name',
+                'location-gemkey',
+                'location-street',
+                'location-zip',
+                'location-city',
+            ),
+            new RceEventAddress(
+                'organizer-name',
+                'organizer-gemkey',
+                'organizer-street',
+                'organizer-zip',
+                'organizer-city',
+            ),
+        );
+        return new RceEventListItem(
+            '123',
+            'myname',
+            true,
+            [$eventDate],
+            'description',
+            false,
+            false,
+            'https://www.example.com/ticket',
+            null,
+            null,
+            true,
+            null,
+            $addresses,
+            'keyword',
+            [],
+        );
+    }
+
+    private function createHierarchyLoader(): ResourceHierarchyLoader
+    {
+        $loader = $this->createStub(ResourceHierarchyLoader::class);
+        $this->createCategoryTree();
+        $resourceMap = $this->resourceMap;
+        $loader->method('load')
+            ->willReturnCallback(
+                function (ResourceLocation $location) use ($resourceMap) {
+                    return $resourceMap[$location->location];
+                },
+            );
+        $childrenResourceMap = $this->childrenResourceMap;
+        $loader->method('getChildrenLocations')
+            ->willReturnCallback(
+                function (
+                    Resource $resource,
+                ) use ($childrenResourceMap) {
+                    return $childrenResourceMap[$resource->location] ?? [];
+                },
+            );
+        $primaryPathMap = $this->primaryPathMap;
+        $loader->method('loadPrimaryPath')
+            ->willReturnCallback(
+                function (
+                    ResourceLocation $location,
+                ) use ($primaryPathMap) {
+                    return $primaryPathMap[$location->location];
+                },
+            );
+        $loader->method('loadPrimaryParent')
+            ->willReturnCallback(
+                function (
+                    ResourceLocation $location,
+                ) use ($primaryPathMap) {
+                    $parentPath = $primaryPathMap[$location->location];
+                    return $parentPath[count($parentPath) - 2] ?? null;
+                },
+            );
+
+        return $loader;
+    }
+
+    private function createCategoryTree(): void
+    {
+        $root = $this->createResource(
+            '10',
+            '/category/root.php',
+            'some-category-root',
+            'some-category-root',
+        );
+        $childA = $this->createResource(
+            '11',
+            '/category/childA.php',
+            'some-category-a',
+            'some-category-a',
+        );
+        $childB = $this->createResource(
+            '12',
+            '/category/childB.php',
+            'some-category-b',
+            'some-category-b',
+        );
+
+        $this->kickerCategoryResourceLocation = $root->location;
+        $this->resourceMap[$root->location] = $root;
+        $this->resourceMap[$childA->location] = $childA;
+        $this->resourceMap[$childB->location] = $childB;
+
+        $this->childrenResourceMap[$root->location] = [
+            $childA,
+            $childB,
+        ];
+        $this->primaryPathMap[$root->location] = [$root];
+        $this->primaryPathMap[$childA->location] = [
+            $root,
+            $childA,
+        ];
+        $this->primaryPathMap[$childB->location] = [
+            $root,
+            $childB,
+        ];
+    }
+
+
+
+    private function createResource(
+        string $id,
+        string $location,
+        string $anchor,
+        string $name,
+    ): Resource {
+        return new Resource(
+            $location,
+            $id,
+            $name,
+            'objectType',
+            ResourceLanguage::default(),
+            new DataBag([
+                'anchor' => $anchor,
+                'base' => [
+                    'title' => $name,
+                ],
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
Event instances can have a "main category" ("Haupt-Kategorie"). If set, it dictates that the teaser kicker of each event should be constructed from the children of this category. E.g. if the main category is "Zielgruppen", the kicker of an event that has the categories "Jugendliche" and "Senioren" should be "Jugendliche | Senioren". This is/was the default Sitekit behaviour.
<img width="1966" height="534" alt="image" src="https://github.com/user-attachments/assets/bf15f945-10dc-4f6e-a53f-8911aced04a3" />

Currently, however, this does not work with RCE events. The RCE indexer does not know about the "main category" . It simply fills the `sp_meta_string_kicker`-field with the theme name of each rce event.

This PR tries to restore the old behavior described above
- Added the attribute `kickerCategoryResourceLocation` to the indexer config. This is the resource location of the "main category".
- Added an additional document enricher, the `DefaultSchema2xRceEventCategoryDocumentEnricher`. For each rce event, it tries to construct the kicker based on the passed `kickerCategoryResourceLocation`. 