### PR TITLE
feat(rce): filter out inactive events during indexing

### DIFF
--- a/src/Service/Indexer/RceEventIndexerDateFilter.php
+++ b/src/Service/Indexer/RceEventIndexerDateFilter.php
@@ -24,6 +24,9 @@ class RceEventIndexerDateFilter implements RceEventIndexerFilter
         RceEventListItem $event,
         RceEventDate $eventDate,
     ): bool {
-        return !$eventDate->blacklisted && $eventDate->startDate >= $this->date;
+        return
+            $event->active
+            && !$eventDate->blacklisted
+            && $eventDate->startDate >= $this->date;
     }
 }

--- a/test/Service/Indexer/RceEventIndexerDateFilterTest.php
+++ b/test/Service/Indexer/RceEventIndexerDateFilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Atoolo\EventsCalendar\Test\Service\Indexer;
 
+use Atoolo\EventsCalendar\Dto\RceEvent\RceEventAddresses;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventDate;
 use Atoolo\EventsCalendar\Dto\RceEvent\RceEventListItem;
 use Atoolo\EventsCalendar\Service\Indexer\RceEventIndexerDateFilter;
@@ -29,6 +30,7 @@ class RceEventIndexerDateFilterTest extends TestCase
             cancelled: false,
             postponed: false,
         );
+        $event = $this->createEvent([$eventDate]);
 
         $this->assertTrue(
             $filter->accept($event, $eventDate),
@@ -43,7 +45,6 @@ class RceEventIndexerDateFilterTest extends TestCase
         );
 
         $date = new DateTime('2023-07-05');
-        $event = $this->createStub(RceEventListItem::class);
         $eventDate  = new RceEventDate(
             hashId: '',
             startDate: $date,
@@ -53,6 +54,7 @@ class RceEventIndexerDateFilterTest extends TestCase
             cancelled: false,
             postponed: false,
         );
+        $event = $this->createEvent([$eventDate]);
 
         $this->assertTrue(
             $filter->accept($event, $eventDate),
@@ -75,10 +77,58 @@ class RceEventIndexerDateFilterTest extends TestCase
             cancelled: false,
             postponed: false,
         );
+        $event = $this->createEvent([$eventDate]);
 
         $this->assertFalse(
             $filter->accept($event, $eventDate),
             'Event should not be accepted',
+        );
+    }
+
+    public function testWithInactiveEvent(): void
+    {
+        $filter = new RceEventIndexerDateFilter();
+
+        $now = new DateTime();
+        $event = $this->createStub(RceEventListItem::class);
+        $eventDate  = new RceEventDate(
+            hashId: '',
+            startDate: $now,
+            endDate: $now,
+            blacklisted: false,
+            soldOut: false,
+            cancelled: false,
+            postponed: false,
+        );
+        $event = $this->createEvent([$eventDate], false);
+
+        $this->assertFalse(
+            $filter->accept($event, $eventDate),
+            'Event should not be accepted',
+        );
+    }
+
+    /**
+     * @param RceEventDate[] $date
+     */
+    private function createEvent(array $eventDates, bool $active = true): RceEventListItem
+    {
+        return new RceEventListItem(
+            'id',
+            'name',
+            $active,
+            $eventDates,
+            'description',
+            true,
+            true,
+            'https://ticketlink',
+            null,
+            null,
+            false,
+            null,
+            new RceEventAddresses(),
+            'keywords',
+            [],
         );
     }
 }


### PR DESCRIPTION
Inactive rce events should not be indexed. 

Restores [this](https://gitlab.sitepark.com/sitekit/events-calendar-php/-/blob/main/php/SP/EventsCalendar/ComponentModel/RceEvent/XmlImport.php#L503) behavior of the sitekit rce importer. 